### PR TITLE
fix: stabilize auth session handling

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -32,15 +32,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         if (!mounted) return;
 
-        // Only update state for significant events to prevent loops
-        if (event === 'SIGNED_IN' || event === 'SIGNED_OUT' || event === 'TOKEN_REFRESHED') {
+        // Only update state when we have a session or the user explicitly signed out.
+        if (session) {
           setSession(session);
-          setUser(session?.user ?? null);
-          
-          // Create/update profile only on sign in, not on token refresh
-          if (event === 'SIGNED_IN' && session?.user) {
+          setUser(session.user);
+
+          // Create/update profile only on sign in
+          if (event === 'SIGNED_IN') {
             console.log('✅ User signed in:', session.user.email);
-            
+
             // Use setTimeout to prevent blocking auth flow
             setTimeout(() => {
               supabase
@@ -61,10 +61,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 });
             }, 100);
           }
-
-          if (event === 'SIGNED_OUT') {
-            console.log('🚪 User signed out');
-          }
+        } else if (event === 'SIGNED_OUT') {
+          // Explicit sign out
+          console.log('🚪 User signed out');
+          setSession(null);
+          setUser(null);
         }
 
         setLoading(false);


### PR DESCRIPTION
## Summary
- avoid clearing session when Supabase emits token refresh events without a session
- ensure user state only resets on explicit sign out

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892b3df8188832ea2f2c1eb36825aca