### PR TITLE
fix: handle supabase session on auth

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -106,9 +106,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         email: email.trim().toLowerCase(),
         password: password,
       });
-      
+
       console.log('📞 Sign in response:', data, error);
-      
+
       if (error) {
         console.error('❌ Sign in error:', error);
         if (error.message.includes('Invalid login credentials')) {
@@ -120,7 +120,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
         throw new Error('Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.');
       }
-      
+
+      if (data?.session) {
+        setSession(data.session);
+        setUser(data.session.user);
+      }
+
       toast({
         title: "Erfolgreich angemeldet",
         description: "Willkommen zurück!",
@@ -193,6 +198,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setLoading(true);
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
+      setSession(null);
+      setUser(null);
       toast({
         title: "Erfolgreich abgemeldet",
         description: "Bis bald!",

--- a/src/hooks/useSecureAuth.tsx
+++ b/src/hooks/useSecureAuth.tsx
@@ -121,7 +121,7 @@ export function SecureAuthProvider({ children }: { children: ReactNode }) {
         email: sanitizedEmail.toLowerCase(),
         password: password,
       });
-      
+
       if (error) {
         setLoginAttempts(prev => prev + 1);
         console.error('❌ Secure sign in error:', error.message);
@@ -136,7 +136,14 @@ export function SecureAuthProvider({ children }: { children: ReactNode }) {
         }
         throw new Error('Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.');
       }
-      
+
+      if (data?.session) {
+        setSession(data.session);
+        setUser(data.session.user);
+        setLoginAttempts(0);
+        setIsLocked(false);
+      }
+
       // Reset rate limiter on successful login
       authRateLimiter.reset(rateLimitKey);
       
@@ -232,7 +239,11 @@ export function SecureAuthProvider({ children }: { children: ReactNode }) {
       setLoading(true);
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
-      
+      setSession(null);
+      setUser(null);
+      setLoginAttempts(0);
+      setIsLocked(false);
+
       toast({
         title: "Erfolgreich abgemeldet",
         description: "Bis bald!",

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -26,15 +26,19 @@ export const signInWithEmail = async (email: string, password: string) => {
       email: email.trim().toLowerCase(),
       password: password,
     });
-    
+
     if (error) {
       throw error;
     }
-    
-    return { data, error: null };
+
+    return {
+      user: data.user ?? null,
+      session: data.session ?? null,
+      error: null
+    };
   } catch (error) {
     console.error('Sign in error:', error);
-    return { data: null, error };
+    return { user: null, session: null, error };
   }
 };
 


### PR DESCRIPTION
## Summary
- synchronize session and user state after sign-in
- clear local auth state on sign-out
- expose session and user in auth utility sign-in

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_6892b63da550832eb4e69ea7f8b258e8